### PR TITLE
refactor: now the history will only appear in the burger menu

### DIFF
--- a/src/components/Header/MoreOptions.tsx
+++ b/src/components/Header/MoreOptions.tsx
@@ -3,12 +3,14 @@ import { FC } from 'react'
 import {
     Menu, MenuButton, MenuList,
     MenuItem, useColorMode, IconButton,
-    HStack, Text
+    HStack, Text, useDisclosure
 } from '@chakra-ui/react';
 import {
     HamburgerIcon, InfoIcon, MoonIcon,
-    SunIcon
+    SunIcon, TimeIcon
 } from '@chakra-ui/icons'
+
+import { OrderHistory } from "../OrderHistory/OrderHistory";
 
 export const MoreOptions: FC = () => {
 
@@ -18,7 +20,10 @@ export const MoreOptions: FC = () => {
         return colorMode === 'light' ? <MoonIcon /> : <SunIcon />
     }
 
+	const { isOpen, onOpen, onClose } = useDisclosure();
+
     return (
+		<>
         <Menu
             autoSelect={false}
             closeOnSelect={false}
@@ -47,7 +52,19 @@ export const MoreOptions: FC = () => {
                         <InfoIcon />
                     </HStack>
                 </MenuItem>
+                <MenuItem
+					onClick={onOpen}
+				>
+                    <HStack w="full" justifyContent="space-between" >
+                        <Text>
+							Recent orders
+                        </Text>
+                        <TimeIcon />
+                    </HStack>
+                </MenuItem>
             </MenuList>
         </Menu>
+		<OrderHistory isOpen={isOpen} onOpen={onOpen} onClose={onClose}/>
+		</>		
     )
 }

--- a/src/components/OrderHistory/HistoryCard.tsx
+++ b/src/components/OrderHistory/HistoryCard.tsx
@@ -34,6 +34,8 @@ export const HistoryCard: FC<Props> = ({ quantitySold, quantityReceived }) => {
 			fontSize='1xl'
 			px={4}
 			py={2}
+			textAlign='left'
+			w='100%'
 		>
 			{currentTab === "Buy"? <BuyText /> : <SellText />}
 		</Text> 

--- a/src/components/Swap/ActionsTabs.tsx
+++ b/src/components/Swap/ActionsTabs.tsx
@@ -6,7 +6,6 @@ import { FC } from "react";
 import { Props } from "../../types/TabProps/TabProps";
 import { SellRektTab } from "./SellRektTab";
 import { BuyRektTab } from "./BuyRektTab";
-import { RektHistory } from "./RektHistory";
 import { useSwapStore } from '../../stores/SwapStore';
 import { ACTION_TABS } from "./responsive/breakpoints";
 
@@ -56,7 +55,6 @@ export const ActionsTabs = () => {
 					))}
 				</TabPanels>
 			</Tabs>
-			<RektHistory/>
 		</VStack>
     )
 }

--- a/src/types/HistoryProps/HistoryProps.ts
+++ b/src/types/HistoryProps/HistoryProps.ts
@@ -1,0 +1,5 @@
+export type Props = {
+    isOpen: boolean;
+	onOpen: () => void;
+	onClose: () => void;
+}


### PR DESCRIPTION
Solo se mostrará el historial en un Modal Dialog en el menú burger. Le faltan muchas cosas, entre estas:
* Lanzar el historial automáticamente ante cada transacción.
* Mostrar un spinner para tx's que no se han completado.
* Quitar el spinner una vez una tx se ha completado.
* Una vez una tx de venta de REKT haya entrado en cola quitar el spinner acutal, poner otro, y dar feedback con la información correspondiente. Algo del tipo "Your transaction is being processed by the Batcher".
* Mostrar más información sobre las ventas, como podría ser la fecha de las mismas. Para ello, el componente `HistoryCard` debería de tener como argumentos un objeto de tipo transacción completa, y no datos específicos sobre la transacción, lo cual es bastante chapucero.